### PR TITLE
Also filter out watched non db items

### DIFF
--- a/resources/lib/playback.py
+++ b/resources/lib/playback.py
@@ -403,10 +403,11 @@ class PlaybackList:
                 elif item.resumetime and item.totaltime:
                     percent_played = (item.resumetime / item.totaltime) * 100
                     # Use the user set playcount_minium_percent if there is one, or fallback to Kodi default 90 percent
-                    playcount_minium_percent = float(get_advancedsetting('video/playcountminimumpercent')) or 90.0
+                    setting = float(get_advancedsetting('video/playcountminimumpercent')) or None
+                    playcount_minium_percent = float(setting) if setting else 90.0
                     if percent_played >= playcount_minium_percent:
                         list_needs_save = True
-                        Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played is over playcount_minium_percent {playcount_minium_percent}%: [{item.pluginlabel}]")
+                        Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played over playcount_minium_percent {playcount_minium_percent}%: [{item.pluginlabel}]")
                         paths_to_remove.append(item.path)
 
             if paths_to_remove:

--- a/resources/lib/playback.py
+++ b/resources/lib/playback.py
@@ -391,7 +391,7 @@ class PlaybackList:
         if self.remove_watched_playbacks:
             paths_to_remove = []
             for item in list(self.list):
-                # BD item?  Is it marked as watched in the DB?
+                # DB item?  Is it marked as watched in the DB?
                 if item.dbid:
                     playcount = get_playcount(item.type, item.dbid)
                     if playcount and playcount > 0:
@@ -403,11 +403,11 @@ class PlaybackList:
                 elif item.resumetime and item.totaltime:
                     percent_played = (item.resumetime / item.totaltime) * 100
                     # Use the user set playcount_minium_percent if there is one, or fallback to Kodi default 90 percent
-                    setting = float(get_advancedsetting('video/playcountminimumpercent')) or None
-                    playcount_minium_percent = float(setting) if setting else 90.0
+                    setting = get_advancedsetting('video/playcountminimumpercent')
+                    playcount_minium_percent = float(setting) if setting and setting != 0 else 90.0
                     if percent_played >= playcount_minium_percent:
                         list_needs_save = True
-                        Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played over playcount_minium_percent {playcount_minium_percent}%: [{item.pluginlabel}]")
+                        Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played over playcount_minium_percent {playcount_minium_percent}%): [{item.pluginlabel}]")
                         paths_to_remove.append(item.path)
 
             if paths_to_remove:

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -4,7 +4,7 @@ import xbmcvfs
 
 from bossanova808.constants import HOME_WINDOW, PROFILE, ADDON
 from bossanova808.logger import Logger
-from bossanova808.utilities import get_kodi_setting, set_property, clear_property
+from bossanova808.utilities import get_kodi_setting, set_property, clear_property, get_advancedsetting
 from resources.lib.playback import PlaybackList
 
 

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -4,7 +4,7 @@ import xbmcvfs
 
 from bossanova808.constants import HOME_WINDOW, PROFILE, ADDON
 from bossanova808.logger import Logger
-from bossanova808.utilities import get_kodi_setting, set_property, clear_property, get_advancedsetting
+from bossanova808.utilities import get_kodi_setting, set_property, clear_property
 from resources.lib.playback import PlaybackList
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Cleanup now respects your Kodi “Minimum % played” setting for items without a library entry, automatically removing videos once watched past the threshold (defaults to 90% if unset).
- Bug Fixes
  - More consistent watched detection using Kodi DB playcounts and improved handling for non-library items by queuing paths for removal.
  - Enhanced logging for clearer removal decisions and fewer missed cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->